### PR TITLE
Fix too many values to unpack when gh file not exists

### DIFF
--- a/ooi_harvester/utils/github.py
+++ b/ooi_harvester/utils/github.py
@@ -40,7 +40,7 @@ def write_process_status_json(status_json, branch=GH_MAIN_BRANCH):
             branch=branch,
         )
     except Exception as e:
-        _, response = e.args
+        response = e.args[1]
         if response['message'] == 'Not Found':
             repo.create_file(
                 PROCESS_STATUS_PATH_STR,
@@ -72,7 +72,7 @@ def write_request_status_json(status_json, branch=GH_MAIN_BRANCH):
             branch=branch,
         )
     except Exception as e:
-        _, response = e.args
+        response = e.args[1]
         if response['message'] == 'Not Found':
             repo.create_file(
                 REQUEST_STATUS_PATH_STR,


### PR DESCRIPTION
This PR fixes the too many values to unpack error when file doesn't exist in github.