### PR TITLE
Revert to using custom _append_zarr

### DIFF
--- a/ooi_harvester/processor/__init__.py
+++ b/ooi_harvester/processor/__init__.py
@@ -432,14 +432,17 @@ def append_to_zarr(mod_ds, store, encoding, logger=None):
         logger.warning("Nothing to append.")
     else:
         logger.info("Appending zarr file.")
-        mod_ds.to_zarr(
-            store,
-            consolidated=True,
-            compute=True,
-            mode='a',
-            append_dim=append_dim,
-            safe_chunks=False,
-        )
+        # 11/17/2022 Don.S: Currently some issues with xarray to zarr with large dimensions
+        #                   See https://github.com/pydata/xarray/issues/6640
+        # mod_ds.to_zarr(
+        #     store,
+        #     consolidated=True,
+        #     compute=True,
+        #     mode='a',
+        #     append_dim=append_dim,
+        #     safe_chunks=False,
+        # )
+        _append_zarr(store, mod_ds, append_dim=append_dim, consolidated=True)
 
     return True
 

--- a/ooi_harvester/processor/utils.py
+++ b/ooi_harvester/processor/utils.py
@@ -208,18 +208,16 @@ def _prepare_ds_to_append(store, ds_to_append):
     return ds_to_append
 
 
-def _append_zarr(store, ds_to_append, append_dim='time'):
+def _append_zarr(store, ds_to_append, append_dim='time', consolidated=True):
     existing_zarr = zarr.open_group(store, mode='a')
-
-    # Remove append_dim duplicates by checking for existing tail
-    if existing_zarr[append_dim][-1] == ds_to_append[append_dim].data[0]:
-        ds_to_append = ds_to_append.drop_isel({append_dim: 0})
 
     for var_name, var_data in ds_to_append.variables.items():
         if any([append_dim in dim for dim in var_data.dims]):
             existing_arr = existing_zarr[var_name]
             existing_arr.append(var_data.values)
-    zarr.consolidate_metadata(store)
+    
+    if consolidated:
+        zarr.consolidate_metadata(store)
 
 
 def _reindex_zarr(store, dim_indexer):


### PR DESCRIPTION
## Overview

This PR reverts back to using the `_append_zarr` function that I've created since for some reason there are issues with xarray's `to_zarr` with large dimension. See https://github.com/pydata/xarray/issues/6640