### PR TITLE
Catch data response missing errors and get prefect version

### DIFF
--- a/ooi_harvester/pipelines/stream/tasks.py
+++ b/ooi_harvester/pipelines/stream/tasks.py
@@ -344,7 +344,9 @@ def get_request_response(stream_harvest: StreamHarvest, logger=None):
         # may be due to auto deletion by S3
         logger.warning(f"Missing data response file: {stream_harvest.status.data_response}")
         status_json = stream_harvest.status.dict()
-        if "_daily" in stream_harvest.status.data_response:
+
+        # daily harvest
+        if stream_harvest.status.data_response.endswith('daily'):
             status_json.update(
                 {
                     'status': 'success',
@@ -353,7 +355,8 @@ def get_request_response(stream_harvest: StreamHarvest, logger=None):
                     'data_ready': True,
                 }
             )
-        elif "_refresh" in stream_harvest.status.data_response:
+        # refresh harvest
+        elif stream_harvest.status.data_response.endswith('refresh'):
             status_json.update(
                 {
                     'status': 'unknown',

--- a/ooi_harvester/settings/models.py
+++ b/ooi_harvester/settings/models.py
@@ -1,12 +1,17 @@
+import os
 from pydantic import BaseSettings, BaseModel, Field, PyObject, validator
-import prefect
+from ..utils.core import prefect_version
 
+PREFECT_VERSION = prefect_version()
 
 def get_prefect_secret(key):
-    prefect_secret = prefect.client.Secret(key)
-    if prefect_secret.exists():
-        return prefect_secret.get()
-    return None
+    if PREFECT_VERSION < (2, 0, 0):
+        import prefect
+        prefect_secret = prefect.client.Secret(key)
+        if prefect_secret.exists():
+            return prefect_secret.get()
+        return None
+    return os.environ.get(key, None)
 
 
 class GithubStatusDefaults(BaseModel):

--- a/ooi_harvester/utils/core.py
+++ b/ooi_harvester/utils/core.py
@@ -1,0 +1,9 @@
+"""
+Core utility functions
+"""
+from typing import Tuple
+
+def prefect_version() -> Tuple[int, int, int]:
+    """Get prefect version"""
+    import prefect
+    return tuple([int(n) for n in prefect.__version__.split(".")])


### PR DESCRIPTION
## Overview

This PR adds additional functionality to catch `FileNotFoundError` raised when the data response json file is missing from the `ooinet-requests` folder in S3. The file may be missing due to the auto bucket clean up. In this case, the data should be re-requested. 

Additionally, a `core.py` module is added within utils with a new function `prefect_version`, which get a tuple format of the prefect version so it can help with 2.0 transition.