### PR TITLE
except KeyError for stream_dict on status other than 200, log excepted streams

### DIFF
--- a/ooi_harvester/utils/conn.py
+++ b/ooi_harvester/utils/conn.py
@@ -182,12 +182,18 @@ def retrieve_deployments(refdes):
     return deployments
 
 
-def fetch_streams(inst):
+def fetch_streams(inst): # instruments
     logger.debug(inst["reference_designator"])
     streams_list = []
+    excepted_streams_list = []
     for stream in inst["streams"]:
         newst = stream.copy()
-        newst.update(get_stream(stream["stream"]))
+        try:
+            newst.update(get_stream(stream["stream"]))
+        except KeyError as e:
+            logger.warning(f"{e} - request for {stream} may have returned code other than 200")
+            excepted_streams_list.append(stream)
+
         streams_list.append(
             dict(
                 reference_designator=inst["reference_designator"],
@@ -197,6 +203,10 @@ def fetch_streams(inst):
                 **newst,
             )
         )
+
+    if len(excepted_streams_list) != 0:
+        logger.warning(f"The streams: {excepted_streams_list} may have returned codes other than 200")
+
     return streams_list
 
 


### PR DESCRIPTION
Is this similar to what you envisioned - to log a list of streams that returned other than 200 codes? 

I'm unsure of the downstream consequences here, but send_request can return None so maybe we are safe? https://github.com/ooi-data/ooi-harvester/blob/bugfix/stream_dict-json-keyerror/ooi_harvester/utils/conn.py#L235-L264